### PR TITLE
Fix Divergence Map: remove broken spread calculation (#8)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,5 +49,4 @@ plugins/magi/
 - Overall Analysis is 4-6 lines, leading with the most important deliberation finding
 - Verdicts are: Approve / Reject / Conditional Approval
 - Final judgment follows majority rule (2:1 or 3:0)
-- Confidence degrades on high divergence (spread ≥ 3 drops confidence one level)
 - Partial results: 2/3 = warning + capped confidence; 1/3 or 0/3 = no verdict

--- a/plugins/magi/skills/magi/SKILL.md
+++ b/plugins/magi/skills/magi/SKILL.md
@@ -253,25 +253,23 @@ Report the results in the following format (use Markdown tables for scores, keep
 
 ### Divergence Map
 
-Compare all axes across agents side-by-side. Flag high-divergence axes (spread ≥ 2) with ⚠️.
+Score overview across all agents and axes. Each axis is evaluated by a single agent — cross-agent spread is not applicable. For cross-agent divergence, see Phase 3.5 Contention Analysis (verdict-level disagreement).
 
-| Axis | MELCHIOR | BALTHASAR | CASPAR | Spread | |
-|------|----------|-----------|--------|--------|-|
-| Correctness/Rigor | (score) | — | — | — | |
-| Performance | (score) | — | — | — | |
-| Security | (score) | — | — | — | |
-| Technical Consistency | (score) | — | — | — | |
-| Maintainability | — | (score) | — | — | |
-| Testability | — | (score) | — | — | |
-| Operability | — | (score) | — | — | |
-| Team Impact | — | (score) | — | — | |
-| Design Elegance | — | — | (score) | — | |
-| Innovation | — | — | (score) | — | |
-| Feasibility | — | — | (score) | — | |
-| Adaptability | — | — | (score) | — | |
+| Agent | Axis | Score |
+|-------|------|-------|
+| MELCHIOR-1 | Correctness/Rigor | (1-5) |
+| MELCHIOR-1 | Performance | (1-5) |
+| MELCHIOR-1 | Security | (1-5) |
+| MELCHIOR-1 | Technical Consistency | (1-5) |
+| BALTHASAR-2 | Maintainability | (1-5) |
+| BALTHASAR-2 | Testability | (1-5) |
+| BALTHASAR-2 | Operability | (1-5) |
+| BALTHASAR-2 | Team Impact | (1-5) |
+| CASPAR-3 | Design Elegance | (1-5) |
+| CASPAR-3 | Innovation | (1-5) |
+| CASPAR-3 | Feasibility | (1-5) |
+| CASPAR-3 | Adaptability | (1-5) |
 
-- **Spread** = max score − min score among agents that evaluated that axis
-- Axes with spread ≥ 2 are flagged with ⚠️ in the rightmost column
 - If Phase 3.5 contention analysis was performed, insert it here (before Final Judgment)
 
 ```
@@ -299,7 +297,6 @@ Compare all axes across agents side-by-side. Flag high-divergence axes (spread �
 - **Majority** (2:1): Adopt majority verdict. Confidence: Medium. Minority concerns noted in conditions
 - **Conditional Approval** counts as Approve. However, conditions are aggregated in the final verdict
 - **Three-way split** (all different verdicts): Indeterminate. Confidence: Low. Present all views and defer to user
-- **Confidence Degradation**: If any axis in the Divergence Map has a spread ≥ 3, confidence drops one level (High → Medium, Medium → Low). This stacks with the 2:1 split rule — a 2:1 split with a ≥ 3-point divergence results in Low confidence
 
 ### Risk Summary
 


### PR DESCRIPTION
## Summary
- Convert Divergence Map from broken spread-analysis table to clean score overview (Agent, Axis, Score)
- Remove dead Confidence Degradation rule (depended on per-axis spread which is always 0)
- Remove outdated spread reference from CLAUDE.md

## Test plan
- [x] Valid Markdown syntax
- [x] Section headers follow conventions
- [x] YAML frontmatter intact
- [x] Cross-file references consistent

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated divergence assessment presentation to display individual agent-axis scores rather than cross-agent comparisons.
  * Clarified divergence handling workflow with reference to Phase 3.5 Contention Analysis.
  * Removed legacy confidence threshold guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->