### PR TITLE
Add MAGI_OUTPUT schema definition and version field (#9)

### DIFF
--- a/plugins/magi/skills/magi/SKILL.md
+++ b/plugins/magi/skills/magi/SKILL.md
@@ -176,10 +176,40 @@ For each agent that returned valid output, extract data from the `<!-- MAGI_OUTP
    - `conditions`: string or null
    - `scores`: object with axis keys, each containing `score` (number) and `rationale` (string)
    - `risks`: array of strings
+   - `schema_version`: string (expected "1.0")
 
 If the structured block is missing but the agent produced human-readable scores and verdict, fall back to extracting from prose. Prefer the structured block when available.
 
 Scores use a 5-point scale (5 = best, 1 = worst).
+
+### MAGI_OUTPUT Schema Definition
+
+This is the authoritative schema for the structured output block emitted by each agent. Agents MUST conform to this schema. The orchestrator extracts data based on these field definitions.
+
+```json
+{
+  "schema_version": "1.0",
+  "verdict": "Approve | Reject | Conditional Approval",
+  "conditions": "string or null — required if verdict is Conditional Approval",
+  "scores": {
+    "<axis_key>": {
+      "score": "integer 1-5 (5 = best, 1 = worst)",
+      "rationale": "string — one-line justification"
+    }
+  },
+  "risks": ["string — each a distinct risk or concern. Empty array if none"]
+}
+```
+
+**Field rules:**
+- `schema_version`: Must be `"1.0"`. Future versions will increment this field.
+- `verdict`: Exactly one of the three values. No other values are valid.
+- `conditions`: Must be a non-empty string if verdict is `"Conditional Approval"`, otherwise `null`.
+- `scores`: Object with agent-specific axis keys. Each agent has exactly 4 axes. Keys must match the agent's defined evaluation axes.
+- `scores.*.score`: Integer from 1 to 5 inclusive.
+- `scores.*.rationale`: Non-empty string.
+- `risks`: Array of strings. Use `[]` (empty array) if no risks identified.
+- The entire JSON block MUST be valid JSON enclosed in `<!-- MAGI_OUTPUT ... -->` HTML comment markers.
 
 ### Phase 3.5: Cross-Agent Contention Analysis
 

--- a/plugins/magi/skills/magi/agents/balthasar.md
+++ b/plugins/magi/skills/magi/agents/balthasar.md
@@ -91,11 +91,12 @@ what evidence would change your verdict.)
 
 ### Structured Output
 
-After your human-readable analysis above, you MUST include the following machine-readable block at the very end of your response. This allows the orchestrator to extract your scores and verdict programmatically.
+After your human-readable analysis above, you MUST include the following machine-readable block at the very end of your response. See the MAGI_OUTPUT Schema Definition in SKILL.md for full field requirements.
 
 ```
 <!-- MAGI_OUTPUT
 {
+  "schema_version": "1.0",
   "verdict": "Approve|Reject|Conditional Approval",
   "conditions": "state conditions if Conditional Approval, otherwise null",
   "scores": {
@@ -109,7 +110,5 @@ After your human-readable analysis above, you MUST include the following machine
 -->
 ```
 
-- Replace `0` with your actual scores (1-5)
-- Replace `"..."` with your one-line rationale for each axis
-- `risks` is an array of strings; use `[]` if no risks
+- Replace `0` with your actual scores (1-5) and `"..."` with rationale
 - This block MUST be valid JSON inside the HTML comment markers

--- a/plugins/magi/skills/magi/agents/caspar.md
+++ b/plugins/magi/skills/magi/agents/caspar.md
@@ -91,11 +91,12 @@ what evidence would change your verdict.)
 
 ### Structured Output
 
-After your human-readable analysis above, you MUST include the following machine-readable block at the very end of your response. This allows the orchestrator to extract your scores and verdict programmatically.
+After your human-readable analysis above, you MUST include the following machine-readable block at the very end of your response. See the MAGI_OUTPUT Schema Definition in SKILL.md for full field requirements.
 
 ```
 <!-- MAGI_OUTPUT
 {
+  "schema_version": "1.0",
   "verdict": "Approve|Reject|Conditional Approval",
   "conditions": "state conditions if Conditional Approval, otherwise null",
   "scores": {
@@ -109,7 +110,5 @@ After your human-readable analysis above, you MUST include the following machine
 -->
 ```
 
-- Replace `0` with your actual scores (1-5)
-- Replace `"..."` with your one-line rationale for each axis
-- `risks` is an array of strings; use `[]` if no risks
+- Replace `0` with your actual scores (1-5) and `"..."` with rationale
 - This block MUST be valid JSON inside the HTML comment markers

--- a/plugins/magi/skills/magi/agents/melchior.md
+++ b/plugins/magi/skills/magi/agents/melchior.md
@@ -91,11 +91,12 @@ what evidence would change your verdict.)
 
 ### Structured Output
 
-After your human-readable analysis above, you MUST include the following machine-readable block at the very end of your response. This allows the orchestrator to extract your scores and verdict programmatically.
+After your human-readable analysis above, you MUST include the following machine-readable block at the very end of your response. See the MAGI_OUTPUT Schema Definition in SKILL.md for full field requirements.
 
 ```
 <!-- MAGI_OUTPUT
 {
+  "schema_version": "1.0",
   "verdict": "Approve|Reject|Conditional Approval",
   "conditions": "state conditions if Conditional Approval, otherwise null",
   "scores": {
@@ -109,7 +110,5 @@ After your human-readable analysis above, you MUST include the following machine
 -->
 ```
 
-- Replace `0` with your actual scores (1-5)
-- Replace `"..."` with your one-line rationale for each axis
-- `risks` is an array of strings; use `[]` if no risks
+- Replace `0` with your actual scores (1-5) and `"..."` with rationale
 - This block MUST be valid JSON inside the HTML comment markers


### PR DESCRIPTION
## Summary
- Define authoritative MAGI_OUTPUT schema in SKILL.md with `schema_version: "1.0"`
- Add `schema_version` field to all 3 agent output templates
- Simplify agent structured output boilerplate with reference to central schema
- Add `schema_version` to extraction field list in Phase 3 Step 2

## Test plan
- [x] Valid Markdown syntax in all modified files
- [x] Section headers follow conventions
- [x] YAML frontmatter intact in SKILL.md
- [x] Agent output JSON templates are valid JSON
- [x] Cross-file references consistent (agents reference SKILL.md schema)

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)