### PR TITLE
Refactor SKILL.md into multi-file structure (#13)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,12 @@ plugins/magi/
       melchior.md           — MELCHIOR-1: The Scientist (technical excellence)
       balthasar.md          — BALTHASAR-2: The Mother (sustainability)
       caspar.md             — CASPAR-3: The Woman (pragmatic aesthetics)
+    references/
+      output-format.md      — Phase 4 output templates (NERV aesthetic)
+      judgment-rules.md     — Voting rules and confidence levels
+      schema.md             — MAGI_OUTPUT structured output schema
+    examples/
+      sample-deliberation.md — Example deliberation output
 ```
 
 ## How It Works

--- a/README.md
+++ b/README.md
@@ -73,100 +73,47 @@ Each agent follows an **Internal Deliberation Protocol** — a persona-specific 
 - **Structured Output Schema** — Agents emit machine-readable JSON (`<!-- MAGI_OUTPUT -->`) alongside human-readable analysis for reliable programmatic extraction
 - **Decision Log** — Verdicts are persisted to `.magi/decisions.json`; prior rulings on related topics are surfaced before new deliberations
 - **Configurable Agents** — Drop a `magi.config.json` in your project root to customize agents, personas, and models
-- **Divergence Map** — Cross-agent score comparison table flags high-divergence axes (spread ≥ 2) at a glance
+- **Divergence Map** — Score overview table across all 12 axes for at-a-glance comparison
 - **Contention Analysis** — On 2:1 splits, the dissenter's rationale is quoted and high-divergence axes are highlighted
 - **Partial Results Protocol** — Graceful degradation when agents fail (2/3: warning + capped confidence; 1/3 or 0/3: no verdict)
 - **Interactive Drill-Down** — After verdict delivery, drill into a dissenter's concerns, re-evaluate with amendments, or accept
 
 ## Example Output
 
-> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-> MAGI SYSTEM — Deliberation Results
-> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-**Topic:** Should we migrate from REST to GraphQL?
-
-### MELCHIOR-1 [Scientist] — Verdict: Approve
-
-| Axis | Score |
-|------|-------|
-| Correctness/Rigor | 5 |
-| Performance | 4 |
-| Security | 4 |
-| Technical Consistency | 5 |
-
-> Technically sound. Type safety and schema validation are superior to REST.
-
-### BALTHASAR-2 [Mother] — Verdict: Conditional Approval
-
-| Axis | Score |
-|------|-------|
-| Maintainability | 4 |
-| Testability | 3 |
-| Operability | 4 |
-| Team Impact | 3 |
-
-> Concerns about onboarding cost. Team needs GraphQL training first.
-
-### CASPAR-3 [Woman] — Verdict: Approve
-
-| Axis | Score |
-|------|-------|
-| Design Elegance | 5 |
-| Innovation | 5 |
-| Feasibility | 4 |
-| Adaptability | 4 |
-
-> Beautiful query API. The industry is moving this way.
-
-> ━━━ Final Judgment ━━━
-
-| | MELCHIOR | BALTHASAR | CASPAR |
-|---|---------|-----------|--------|
-| **Verdict** | Approve | Cond. Approval | Approve |
-
-- **Overall Verdict:** Conditional Approval
-- **Confidence:** Medium (2:1)
-- **Conditions:** Team training before full adoption
-
-**Recommended Actions:**
-1. Run a GraphQL pilot on a non-critical service
-2. Conduct team training sessions before full migration
-
-> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+See [plugins/magi/skills/magi/examples/sample-deliberation.md](plugins/magi/skills/magi/examples/sample-deliberation.md) for a full sample deliberation output.
 
 ## Configuration
 
-Create `magi.config.json` in your project root to customize agents:
+Copy [`magi.config.example.json`](magi.config.example.json) to `magi.config.json` in your project root and customize:
 
-```json
-{
-  "agents": [
-    { "name": "MELCHIOR-1", "persona": "The Scientist", "file": "agents/melchior.md", "model": "sonnet" },
-    { "name": "BALTHASAR-2", "persona": "The Mother", "file": "agents/balthasar.md", "model": "sonnet" },
-    { "name": "CASPAR-3", "persona": "The Woman", "file": "agents/caspar.md", "model": "sonnet" }
-  ],
-  "voting": { "quorum": 3 }
-}
+```bash
+cp magi.config.example.json magi.config.json
 ```
 
-Without a config file, the default three MAGI are used.
+Without a config file, the default three MAGI are used. If `magi.config.json` is found but malformed, a warning is displayed and defaults are used.
 
 ## Project Structure
 
 ```
 magi-system/
 ├── .claude-plugin/
-│   └── marketplace.json       # Marketplace catalog
+│   └── marketplace.json          # Marketplace catalog
+├── magi.config.example.json      # Example configuration
 ├── plugins/magi/
 │   ├── .claude-plugin/
-│   │   └── plugin.json        # Plugin manifest
+│   │   └── plugin.json           # Plugin manifest
 │   └── skills/magi/
-│       ├── SKILL.md           # Orchestrator
-│       └── agents/
-│           ├── melchior.md    # The Scientist
-│           ├── balthasar.md   # The Mother
-│           └── caspar.md      # The Woman
+│       ├── SKILL.md              # Orchestrator (core flow)
+│       ├── agents/
+│       │   ├── melchior.md       # The Scientist
+│       │   ├── balthasar.md      # The Mother
+│       │   └── caspar.md         # The Woman
+│       ├── references/
+│       │   ├── output-format.md  # Phase 4 output templates
+│       │   ├── judgment-rules.md # Voting rules & confidence
+│       │   └── schema.md         # MAGI_OUTPUT schema
+│       └── examples/
+│           └── sample-deliberation.md  # Example output
 └── README.md
 ```
 

--- a/plugins/magi/skills/magi/SKILL.md
+++ b/plugins/magi/skills/magi/SKILL.md
@@ -194,32 +194,7 @@ Scores use a 5-point scale (5 = best, 1 = worst).
 
 ### MAGI_OUTPUT Schema Definition
 
-This is the authoritative schema for the structured output block emitted by each agent. Agents MUST conform to this schema. The orchestrator extracts data based on these field definitions.
-
-```json
-{
-  "schema_version": "1.0",
-  "verdict": "Approve | Reject | Conditional Approval",
-  "conditions": "string or null — required if verdict is Conditional Approval",
-  "scores": {
-    "<axis_key>": {
-      "score": "integer 1-5 (5 = best, 1 = worst)",
-      "rationale": "string — one-line justification"
-    }
-  },
-  "risks": ["string — each a distinct risk or concern. Empty array if none"]
-}
-```
-
-**Field rules:**
-- `schema_version`: Must be `"1.0"`. Future versions will increment this field.
-- `verdict`: Exactly one of the three values. No other values are valid.
-- `conditions`: Must be a non-empty string if verdict is `"Conditional Approval"`, otherwise `null`.
-- `scores`: Object with agent-specific axis keys. Each agent has exactly 4 axes. Keys must match the agent's defined evaluation axes.
-- `scores.*.score`: Integer from 1 to 5 inclusive.
-- `scores.*.rationale`: Non-empty string.
-- `risks`: Array of strings. Use `[]` (empty array) if no risks identified.
-- The entire JSON block MUST be valid JSON enclosed in `<!-- MAGI_OUTPUT ... -->` HTML comment markers.
+See [references/schema.md](references/schema.md) for the authoritative schema definition and field rules.
 
 ### Phase 3.5: Cross-Agent Contention Analysis
 
@@ -248,99 +223,9 @@ This contention summary is included in the Phase 4 output (before Final Judgment
 
 ## Phase 4: Deliberation Output
 
-Report the results in the following format (use Markdown tables for scores, keep ━━━ headers for NERV aesthetic):
+Follow the output format defined in [references/output-format.md](references/output-format.md). This includes per-agent score tables, Divergence Map, Final Judgment table, and Recommended Actions — all using the NERV aesthetic (━━━ headers).
 
-```
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  MAGI SYSTEM — Deliberation Results
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-```
-
-**Topic:** (state the topic)
-
-### MELCHIOR-1 [Scientist] — Verdict: (verdict)
-
-| Axis | Score |
-|------|-------|
-| Correctness/Rigor | (1-5) |
-| Performance | (1-5) |
-| Security | (1-5) |
-| Technical Consistency | (1-5) |
-
-> (1-2 line summary of overall analysis)
-
-### BALTHASAR-2 [Mother] — Verdict: (verdict)
-
-| Axis | Score |
-|------|-------|
-| Maintainability | (1-5) |
-| Testability | (1-5) |
-| Operability | (1-5) |
-| Team Impact | (1-5) |
-
-> (1-2 line summary of overall analysis)
-
-### CASPAR-3 [Woman] — Verdict: (verdict)
-
-| Axis | Score |
-|------|-------|
-| Design Elegance | (1-5) |
-| Innovation | (1-5) |
-| Feasibility | (1-5) |
-| Adaptability | (1-5) |
-
-> (1-2 line summary of overall analysis)
-
-### Divergence Map
-
-Score overview across all agents and axes. Each axis is evaluated by a single agent — cross-agent spread is not applicable. For cross-agent divergence, see Phase 3.5 Contention Analysis (verdict-level disagreement).
-
-| Agent | Axis | Score |
-|-------|------|-------|
-| MELCHIOR-1 | Correctness/Rigor | (1-5) |
-| MELCHIOR-1 | Performance | (1-5) |
-| MELCHIOR-1 | Security | (1-5) |
-| MELCHIOR-1 | Technical Consistency | (1-5) |
-| BALTHASAR-2 | Maintainability | (1-5) |
-| BALTHASAR-2 | Testability | (1-5) |
-| BALTHASAR-2 | Operability | (1-5) |
-| BALTHASAR-2 | Team Impact | (1-5) |
-| CASPAR-3 | Design Elegance | (1-5) |
-| CASPAR-3 | Innovation | (1-5) |
-| CASPAR-3 | Feasibility | (1-5) |
-| CASPAR-3 | Adaptability | (1-5) |
-
-- If Phase 3.5 contention analysis was performed, insert it here (before Final Judgment)
-
-```
-━━━ Final Judgment ━━━
-```
-
-| | MELCHIOR | BALTHASAR | CASPAR |
-|---|---------|-----------|--------|
-| **Verdict** | (verdict) | (verdict) | (verdict) |
-
-- **Overall Verdict:** Approve / Reject / Conditional Approval / Indeterminate
-- **Confidence:** High / Medium / Low
-- **Conditions:** (Aggregate conditions if any. Otherwise "None")
-
-**Recommended Actions:**
-1. (1-3 concrete next steps based on deliberation results)
-
-```
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-```
-
-### Judgment Rules
-
-- **Unanimous** (3:0): Final verdict matches. Confidence: High
-- **Majority** (2:1): Adopt majority verdict. Confidence: Medium. Minority concerns noted in conditions
-- **Conditional Approval** counts as Approve. However, conditions are aggregated in the final verdict
-- **Three-way split** (all different verdicts): Indeterminate. Confidence: Low. Present all views and defer to user
-
-### Risk Summary
-
-Consolidate "Risks and Concerns" from all three MAGI, deduplicate, and reflect in recommended actions.
+Apply the judgment rules defined in [references/judgment-rules.md](references/judgment-rules.md) to determine the Overall Verdict, Confidence level, and Risk Summary.
 
 ## Phase 5: Decision Logging
 

--- a/plugins/magi/skills/magi/agents/balthasar.md
+++ b/plugins/magi/skills/magi/agents/balthasar.md
@@ -91,7 +91,7 @@ what evidence would change your verdict.)
 
 ### Structured Output
 
-After your human-readable analysis above, you MUST include the following machine-readable block at the very end of your response. See the MAGI_OUTPUT Schema Definition in SKILL.md for full field requirements.
+After your human-readable analysis above, you MUST include the following machine-readable block at the very end of your response. See [references/schema.md](../references/schema.md) for full field requirements.
 
 ```
 <!-- MAGI_OUTPUT

--- a/plugins/magi/skills/magi/agents/caspar.md
+++ b/plugins/magi/skills/magi/agents/caspar.md
@@ -91,7 +91,7 @@ what evidence would change your verdict.)
 
 ### Structured Output
 
-After your human-readable analysis above, you MUST include the following machine-readable block at the very end of your response. See the MAGI_OUTPUT Schema Definition in SKILL.md for full field requirements.
+After your human-readable analysis above, you MUST include the following machine-readable block at the very end of your response. See [references/schema.md](../references/schema.md) for full field requirements.
 
 ```
 <!-- MAGI_OUTPUT

--- a/plugins/magi/skills/magi/agents/melchior.md
+++ b/plugins/magi/skills/magi/agents/melchior.md
@@ -91,7 +91,7 @@ what evidence would change your verdict.)
 
 ### Structured Output
 
-After your human-readable analysis above, you MUST include the following machine-readable block at the very end of your response. See the MAGI_OUTPUT Schema Definition in SKILL.md for full field requirements.
+After your human-readable analysis above, you MUST include the following machine-readable block at the very end of your response. See [references/schema.md](../references/schema.md) for full field requirements.
 
 ```
 <!-- MAGI_OUTPUT

--- a/plugins/magi/skills/magi/examples/sample-deliberation.md
+++ b/plugins/magi/skills/magi/examples/sample-deliberation.md
@@ -1,0 +1,56 @@
+# Sample Deliberation Output
+
+> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+> MAGI SYSTEM — Deliberation Results
+> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+**Topic:** Should we migrate from REST to GraphQL?
+
+### MELCHIOR-1 [Scientist] — Verdict: Approve
+
+| Axis | Score |
+|------|-------|
+| Correctness/Rigor | 5 |
+| Performance | 4 |
+| Security | 4 |
+| Technical Consistency | 5 |
+
+> Technically sound. Type safety and schema validation are superior to REST.
+
+### BALTHASAR-2 [Mother] — Verdict: Conditional Approval
+
+| Axis | Score |
+|------|-------|
+| Maintainability | 4 |
+| Testability | 3 |
+| Operability | 4 |
+| Team Impact | 3 |
+
+> Concerns about onboarding cost. Team needs GraphQL training first.
+
+### CASPAR-3 [Woman] — Verdict: Approve
+
+| Axis | Score |
+|------|-------|
+| Design Elegance | 5 |
+| Innovation | 5 |
+| Feasibility | 4 |
+| Adaptability | 4 |
+
+> Beautiful query API. The industry is moving this way.
+
+> ━━━ Final Judgment ━━━
+
+| | MELCHIOR | BALTHASAR | CASPAR |
+|---|---------|-----------|--------|
+| **Verdict** | Approve | Cond. Approval | Approve |
+
+- **Overall Verdict:** Conditional Approval
+- **Confidence:** Medium (2:1)
+- **Conditions:** Team training before full adoption
+
+**Recommended Actions:**
+1. Run a GraphQL pilot on a non-critical service
+2. Conduct team training sessions before full migration
+
+> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/plugins/magi/skills/magi/references/judgment-rules.md
+++ b/plugins/magi/skills/magi/references/judgment-rules.md
@@ -1,0 +1,10 @@
+# Judgment Rules
+
+- **Unanimous** (3:0): Final verdict matches. Confidence: High
+- **Majority** (2:1): Adopt majority verdict. Confidence: Medium. Minority concerns noted in conditions
+- **Conditional Approval** counts as Approve. However, conditions are aggregated in the final verdict
+- **Three-way split** (all different verdicts): Indeterminate. Confidence: Low. Present all views and defer to user
+
+## Risk Summary
+
+Consolidate "Risks and Concerns" from all three MAGI, deduplicate, and reflect in recommended actions.

--- a/plugins/magi/skills/magi/references/output-format.md
+++ b/plugins/magi/skills/magi/references/output-format.md
@@ -1,0 +1,84 @@
+# Phase 4: Deliberation Output Format
+
+Report the results in the following format (use Markdown tables for scores, keep ━━━ headers for NERV aesthetic):
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  MAGI SYSTEM — Deliberation Results
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+**Topic:** (state the topic)
+
+### MELCHIOR-1 [Scientist] — Verdict: (verdict)
+
+| Axis | Score |
+|------|-------|
+| Correctness/Rigor | (1-5) |
+| Performance | (1-5) |
+| Security | (1-5) |
+| Technical Consistency | (1-5) |
+
+> (1-2 line summary of overall analysis)
+
+### BALTHASAR-2 [Mother] — Verdict: (verdict)
+
+| Axis | Score |
+|------|-------|
+| Maintainability | (1-5) |
+| Testability | (1-5) |
+| Operability | (1-5) |
+| Team Impact | (1-5) |
+
+> (1-2 line summary of overall analysis)
+
+### CASPAR-3 [Woman] — Verdict: (verdict)
+
+| Axis | Score |
+|------|-------|
+| Design Elegance | (1-5) |
+| Innovation | (1-5) |
+| Feasibility | (1-5) |
+| Adaptability | (1-5) |
+
+> (1-2 line summary of overall analysis)
+
+### Divergence Map
+
+Score overview across all agents and axes. Each axis is evaluated by a single agent — cross-agent spread is not applicable. For cross-agent divergence, see Phase 3.5 Contention Analysis (verdict-level disagreement).
+
+| Agent | Axis | Score |
+|-------|------|-------|
+| MELCHIOR-1 | Correctness/Rigor | (1-5) |
+| MELCHIOR-1 | Performance | (1-5) |
+| MELCHIOR-1 | Security | (1-5) |
+| MELCHIOR-1 | Technical Consistency | (1-5) |
+| BALTHASAR-2 | Maintainability | (1-5) |
+| BALTHASAR-2 | Testability | (1-5) |
+| BALTHASAR-2 | Operability | (1-5) |
+| BALTHASAR-2 | Team Impact | (1-5) |
+| CASPAR-3 | Design Elegance | (1-5) |
+| CASPAR-3 | Innovation | (1-5) |
+| CASPAR-3 | Feasibility | (1-5) |
+| CASPAR-3 | Adaptability | (1-5) |
+
+- If Phase 3.5 contention analysis was performed, insert it here (before Final Judgment)
+
+```
+━━━ Final Judgment ━━━
+```
+
+| | MELCHIOR | BALTHASAR | CASPAR |
+|---|---------|-----------|--------|
+| **Verdict** | (verdict) | (verdict) | (verdict) |
+
+- **Overall Verdict:** Approve / Reject / Conditional Approval / Indeterminate
+- **Confidence:** High / Medium / Low
+- **Conditions:** (Aggregate conditions if any. Otherwise "None")
+
+**Recommended Actions:**
+1. (1-3 concrete next steps based on deliberation results)
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```

--- a/plugins/magi/skills/magi/references/schema.md
+++ b/plugins/magi/skills/magi/references/schema.md
@@ -1,0 +1,29 @@
+# MAGI_OUTPUT Schema Definition
+
+This is the authoritative schema for the structured output block emitted by each agent. Agents MUST conform to this schema. The orchestrator extracts data based on these field definitions.
+
+```json
+{
+  "schema_version": "1.0",
+  "verdict": "Approve | Reject | Conditional Approval",
+  "conditions": "string or null — required if verdict is Conditional Approval",
+  "scores": {
+    "<axis_key>": {
+      "score": "integer 1-5 (5 = best, 1 = worst)",
+      "rationale": "string — one-line justification"
+    }
+  },
+  "risks": ["string — each a distinct risk or concern. Empty array if none"]
+}
+```
+
+## Field Rules
+
+- `schema_version`: Must be `"1.0"`. Future versions will increment this field.
+- `verdict`: Exactly one of the three values. No other values are valid.
+- `conditions`: Must be a non-empty string if verdict is `"Conditional Approval"`, otherwise `null`.
+- `scores`: Object with agent-specific axis keys. Each agent has exactly 4 axes. Keys must match the agent's defined evaluation axes.
+- `scores.*.score`: Integer from 1 to 5 inclusive.
+- `scores.*.rationale`: Non-empty string.
+- `risks`: Array of strings. Use `[]` (empty array) if no risks identified.
+- The entire JSON block MUST be valid JSON enclosed in `<!-- MAGI_OUTPUT ... -->` HTML comment markers.


### PR DESCRIPTION
## Summary
- Extract Phase 4 output templates → `references/output-format.md`
- Extract voting rules & confidence → `references/judgment-rules.md`
- Move MAGI_OUTPUT schema → `references/schema.md`
- Extract sample output from README → `examples/sample-deliberation.md`
- Slim SKILL.md from 427 → 311 lines (core orchestration flow only)
- Update agent files to reference `references/schema.md`
- Update CLAUDE.md and README.md with new directory structure

## Test plan
- [x] Valid Markdown syntax in all files
- [x] Section headers follow conventions
- [x] YAML frontmatter intact in SKILL.md
- [x] Cross-file references consistent (agents → schema.md, SKILL.md → output-format.md, judgment-rules.md)
- [x] README.md project structure matches actual directory layout

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)