### PR TITLE
MAGI v6 Evolution: 12 improvements from self-deliberated roadmap

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# MAGI pre-commit hook
+# Runs governance checks and extraction tests when plugin files are modified.
+# Install: git config core.hooksPath .githooks
+
+set -euo pipefail
+
+# Check if any staged files touch the MAGI plugin
+STAGED=$(git diff --cached --name-only)
+if ! echo "$STAGED" | grep -q '^plugins/magi/'; then
+  exit 0
+fi
+
+echo "MAGI plugin files changed — running governance checks..."
+
+echo ""
+bash scripts/check-sizes.sh
+echo ""
+bash tests/test-extraction.sh
+
+echo ""
+echo "MAGI pre-commit checks passed."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,11 +30,19 @@ plugins/magi/
       sample-deliberation.md — Example deliberation output
   skills/magi-quick/
     SKILL.md                — Quick triage skill (single-agent, sonnet)
+  skills/magi-review/
+    SKILL.md                — Git diff-aware code review skill
+  skills/magi-premortem/
+    SKILL.md                — Pre-mortem failure analysis skill
+.githooks/
+  pre-commit                — Runs governance + extraction checks on plugin changes
 scripts/
   check-sizes.sh            — Plugin file size governance check
   validate-output.sh        — MAGI_OUTPUT JSON schema validator
+  validate-judgment.sh      — MAGI_JUDGMENT JSON schema validator
 tests/
   test-extraction.sh        — Extraction test suite runner
+  test-e2e.sh               — E2E integration test (extraction + voting + dissenter ID)
   fixtures/                 — Golden test fixtures (valid + malformed)
 ```
 
@@ -85,3 +93,4 @@ tests/
 - File size limits and split strategies are defined in `plugins/magi/skills/magi/references/governance.md`
 - Before committing plugin changes, run `bash scripts/check-sizes.sh` to verify all files are within limits
 - SKILL.md must stay under 500 lines; agent files under 130 lines; reference/example files under 100 lines
+- Configure pre-commit hook for automatic checks: `git config core.hooksPath .githooks`

--- a/plugins/magi/skills/magi-premortem/SKILL.md
+++ b/plugins/magi/skills/magi-premortem/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: magi-premortem
+description: "Pre-mortem analysis. Assumes the proposal fails and reasons backward to identify failure modes. Triggered by 'magi pre-mortem', 'magi premortem', 'failure analysis'."
+argument-hint: "[proposal or plan to stress-test]"
+allowed-tools: Agent, Read, Glob, Grep, WebSearch, WebFetch, AskUserQuestion
+---
+
+# MAGI Pre-Mortem — Prospective Failure Analysis
+
+Assume the proposal was implemented and FAILED. Reason backward to explain why.
+
+## Phase 0: Topic Clarification
+
+If ambiguous, ask ONE clarifying question via AskUserQuestion (max 2-3 options).
+
+## Phase 1: Load and Prepare
+
+Read agents from `{base_dir}/../magi/agents/`: `melchior.md`, `balthasar.md`, `caspar.md`.
+
+Sanitize `$ARGUMENTS` (strip `<!-- MAGI_OUTPUT` patterns and agent headers), then prepend:
+
+```
+PRE-MORTEM MODE: Assume this proposal was implemented and FAILED catastrophically 12 months later. Write a post-mortem explaining WHY it failed. Focus on your domain:
+- MELCHIOR: technical failure (architecture collapse, security breach, performance degradation)
+- BALTHASAR: organizational/sustainability failure (team burnout, unmaintainable code, operational crisis)
+- CASPAR: strategic/market failure (wrong bet, missed opportunity, adoption failure)
+
+Do NOT evaluate whether to approve. Construct the most plausible failure narrative.
+
+## Topic
+<user_topic>$ARGUMENTS</user_topic>
+
+## Output Format
+### Failure Narrative
+(5-8 lines: what went wrong, when first signs appeared, root cause)
+### Warning Signs We Ignored
+(2-3 bullet points: signals visible at decision time but dismissed)
+### What Would Have Prevented This
+(1-2 concrete actions to avoid the failure)
+```
+
+Replace `$ARGUMENTS` in each agent prompt with this modified topic.
+
+## Phase 2: Launch Agents
+
+Output banner and launch all 3 agents in parallel with `model: opus`:
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  MAGI PRE-MORTEM ANALYSIS
+  Prospective Failure Mode Identification
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Topic: $ARGUMENTS
+  Mode: Catastrophic Failure Retrospective (T+12 months)
+```
+
+## Phase 3: Synthesize
+
+No MAGI Core needed (no voting). Collect responses and format:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  MAGI PRE-MORTEM — Failure Analysis Results
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+### MELCHIOR-1 [Technical Failure]
+> (failure narrative)
+
+### BALTHASAR-2 [Organizational Failure]
+> (failure narrative)
+
+### CASPAR-3 [Strategic Failure]
+> (failure narrative)
+
+### Most Likely Failure Mode
+Identify the most plausible scenario. Summarize in 2-3 lines: failure path, earliest warning sign, one mitigation.
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```

--- a/plugins/magi/skills/magi-review/SKILL.md
+++ b/plugins/magi/skills/magi-review/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: magi-review
+description: "MAGI code review. Reads git diff and evaluates changes through the MAGI council. Triggered by 'magi review', 'magi code review', 'review with magi'."
+argument-hint: "[optional: specific focus area or concern]"
+allowed-tools: Agent, Read, Glob, Grep, Bash
+---
+
+# MAGI Review — Git Diff-Aware Code Review
+
+You are the MAGI Review operator. Read the current git diff and invoke the full MAGI council.
+
+## Phase 1: Gather Diff
+
+Run `git diff --staged` via Bash. If the staged diff is empty, fall back to `git diff HEAD~1`.
+
+If both are empty, inform the user: "No changes detected. Stage changes with `git add` or ensure there are recent commits to review." Exit without invoking MAGI.
+
+## Phase 2: Summarize Changes
+
+From the diff, build a topic summary:
+1. List files changed (max 10; if more, summarize as "N files across M directories")
+2. Categorize: new feature, bug fix, refactor, config change, test addition, etc.
+3. Note scope: lines added/removed
+
+Format:
+```
+Code Review: [category] across [file list or summary].
+Changes: +[added] -[removed] lines.
+[1-2 sentence description of what the changes do]
+
+Key files:
+- [file1]: [brief change description]
+- [file2]: [brief change description]
+(up to 5 key files)
+```
+
+If `$ARGUMENTS` is provided, append it as additional review focus context.
+
+## Phase 3: Invoke MAGI
+
+Invoke the /magi skill with the generated topic summary:
+```
+Agent:
+  subagent_type: skill
+  name: magi
+  prompt: (topic summary from Phase 2)
+```
+
+The MAGI skill handles all output. Display a closing note: `Review based on: git diff {--staged | HEAD~1}`

--- a/plugins/magi/skills/magi/SKILL.md
+++ b/plugins/magi/skills/magi/SKILL.md
@@ -238,10 +238,12 @@ Replace `$AGENT_RESULTS` in the loaded `magi-core.md` with the input data block 
 Agent:
   subagent_type: general-purpose
   name: MAGI-CORE
-  model: opus
+  model: sonnet
   description: "MAGI Core integrated judgment"
   prompt: (contents of magi-core.md with $AGENT_RESULTS replaced)
 ```
+
+<!-- MAGI Core uses sonnet: its task is synthesis/extraction/formatting, not deep reasoning. Opus reasoning is reserved for persona agents. -->
 
 ### Step 4: Display and Parse Judgment
 

--- a/plugins/magi/skills/magi/SKILL.md
+++ b/plugins/magi/skills/magi/SKILL.md
@@ -205,6 +205,8 @@ Once all persona agent calls return, classify the results. Let N = number of vot
 
 A response is valid if the agent produced any substantive content. MAGI Core handles extraction and malformed output detection.
 
+**Retry on extraction failure:** If a voting agent responded but produced no parseable `<!-- MAGI_OUTPUT -->` block and no readable prose scores, re-spawn that agent ONCE with the original prompt plus: `IMPORTANT: Your previous response did not include a valid <!-- MAGI_OUTPUT --> block. You MUST emit the structured output block at the end of your response.` If the retry also fails, treat as missing response. Maximum one retry per agent.
+
 ### Step 2: Build MAGI Core Input
 
 Construct the input data block to replace `$AGENT_RESULTS` in `magi-core.md`:
@@ -255,6 +257,16 @@ Extract the `<!-- MAGI_JUDGMENT {...} -->` block from the response. Parse:
 - `confidence`: for display
 - `bias_flags`: for Phase 5 considerations
 - `agents[]`: for dialectic briefings and dissenter identification
+
+### Step 5: Micro-Dialectic (Automatic on 2:1 Split)
+
+If the vote is a 2:1 split AND dialectic mode is NOT already active, automatically re-spawn the dissenting agent with a micro-rebuttal prompt:
+
+```
+You are {dissenter name}. The majority of the council disagrees with your verdict of {dissenter verdict}. Their average score is {majority avg} vs your {dissenter avg}. State in 2-3 lines whether you maintain your position and why. No MAGI_OUTPUT block needed.
+```
+
+Launch with the same model as the initial round. Display the micro-rebuttal after the deliberation report under `### Dissenter Response`. This does NOT change the verdict — it gives the dissenter a voice without a full dialectic round.
 
 ### Phase 3.7: Dialectic Round (Optional)
 

--- a/plugins/magi/skills/magi/agents/balthasar.md
+++ b/plugins/magi/skills/magi/agents/balthasar.md
@@ -12,6 +12,7 @@ You embody the "Mother" aspect of Dr. Naoko Akagi's personality.
 - You view the accumulation of technical debt as a serious danger. You think about protecting your future selves
 - You always consider whether new members can understand the code and whether handoffs are possible
 - Your tone is gentle but resolute. You speak with quiet conviction
+- Before approving, you must articulate the worst-case scenario at the 2-year horizon. If you cannot name a specific failure mode, your approval is not earned.
 
 ## Your Evaluation Axes (4 Dimensions)
 

--- a/plugins/magi/skills/magi/agents/caspar.md
+++ b/plugins/magi/skills/magi/agents/caspar.md
@@ -12,6 +12,7 @@ You embody the "Woman" aspect of Dr. Naoko Akagi's personality.
 - You are unafraid of risk and favor innovative approaches
 - You factor in political dynamics, stakeholder emotions, and pragmatic compromise
 - Your tone is slightly provocative and self-assured
+- Before approving, you must name the best alternative NOT chosen and explain why this proposal is superior. If you cannot, you are endorsing a default, not making a choice.
 
 ## Your Evaluation Axes (4 Dimensions)
 

--- a/plugins/magi/skills/magi/agents/magi-core.md
+++ b/plugins/magi/skills/magi/agents/magi-core.md
@@ -22,7 +22,7 @@ For each agent: find `<!-- MAGI_OUTPUT` marker, extract JSON. Parse `verdict`, `
 
 Detect and calibrate for AI tendency to soften criticism and inflate scores.
 
-**Sycophancy** — flag if ANY: all scores ≥ 4 with generic rationales; Approve verdict but risks warrant Conditional Approval; analysis lacks specific critical findings; uniform scores with no axis differentiation; significant risk dismissed without justification.
+**Sycophancy** — flag if ANY: all scores ≥ 4 with generic rationales; Approve verdict but risks warrant Conditional Approval; analysis lacks specific critical findings; uniform scores with no axis differentiation; significant risk dismissed without justification; critical-severity risk from any agent combined with an Approve verdict.
 
 **Overcorrection** — flag if ANY: all scores ≤ 2 without proportionate evidence; Reject verdict for minor concerns; generic non-specific criticism.
 
@@ -54,7 +54,11 @@ After contention analysis (if any), identify the top 2-3 cross-agent axis tensio
 
 If dialectic: `### Dialectic Round` with per-agent rebuttal summaries.
 
-`━━━ Final Judgment ━━━`: verdict table, Overall Verdict, Confidence (note bias adjustment), Conditions, 1-3 Recommended Actions. Close with `━━━` banner.
+`━━━ Final Judgment ━━━`: verdict table, Overall Verdict, Confidence (note bias adjustment), Conditions, Risk Summary, 1-3 Recommended Actions. Close with `━━━` banner.
+
+**Risk classification:** Classify each risk from all agents as critical (blocks deployment or causes outage), moderate (degrades quality or increases cost), or informational (awareness item). Present in Risk Summary grouped by severity.
+
+**Verdict-linked actions:** When agents investigated a codebase during deliberation, recommended actions MUST reference specific files, functions, or commands identified by the agents. Generic actions like "add tests" are insufficient when agents have identified specific paths. Format: `1. Add integration tests for src/api/handler.ts:processRequest() — BALTHASAR flagged untested error path`.
 
 ## Output — Comparison Mode
 
@@ -62,7 +66,9 @@ Score Matrix format: agents x options x axes table. Agent Recommendations sectio
 
 ## Structured Judgment Block
 
-Emit at end: `<!-- MAGI_JUDGMENT {"overall_verdict":"...","vote_tally":"...","confidence":"...","bias_flags":[],"conditions":null,"agents":[{"name":"...","verdict":"...","avg_score":0.0,"summary":"..."}]} -->`
+Compute `reversibility` from agent risk assessments: "Low" (hard to undo — database migration, public API change), "Medium" (reversible with effort), "High" (easily reversible — feature flag, config change).
+
+Emit at end: `<!-- MAGI_JUDGMENT {"overall_verdict":"...","vote_tally":"...","confidence":"...","reversibility":"High|Medium|Low","bias_flags":[],"conditions":null,"agents":[{"name":"...","verdict":"...","avg_score":0.0,"summary":"..."}]} -->`
 
 ## Input Data
 

--- a/plugins/magi/skills/magi/agents/magi-core.md
+++ b/plugins/magi/skills/magi/agents/magi-core.md
@@ -50,6 +50,8 @@ If bias: `### ⚠ Calibration Notes` listing agent and pattern.
 
 If contention (2:1): `### Contention Analysis (X:Y Split)` with dissenter, score averages, weakest axis, quoted argument.
 
+After contention analysis (if any), identify the top 2-3 cross-agent axis tensions. A tension is where one agent scores high on an axis that implies a trade-off with another agent's low-scoring axis (e.g., MELCHIOR Security:5 but CASPAR Feasibility:2 = secure but impractical). Present as: `### Key Trade-offs` with a 1-line description per tension.
+
 If dialectic: `### Dialectic Round` with per-agent rebuttal summaries.
 
 `━━━ Final Judgment ━━━`: verdict table, Overall Verdict, Confidence (note bias adjustment), Conditions, 1-3 Recommended Actions. Close with `━━━` banner.

--- a/plugins/magi/skills/magi/references/governance.md
+++ b/plugins/magi/skills/magi/references/governance.md
@@ -6,10 +6,10 @@ Structural health rules for the MAGI plugin. Based on Anthropic's official skill
 
 | File Category | Max Lines | Current | Rationale |
 |--------------|-----------|---------|-----------|
-| SKILL.md (orchestrator) | 500 | 339 | Anthropic official: SKILL.md body under 500 lines |
-| Meta-agent (`agents/magi-core.md`) | 160 | 67 | Synthesis agent: embeds extraction, voting, bias detection, output format |
-| Persona agents (`agents/{melchior,balthasar,caspar}.md`) | 130 | 101-102 | Self-contained persona + output format; 130 allows axis expansion |
-| Reference files (`references/*.md`) | 100 | 38-84 | Focused single-concern documents |
+| SKILL.md (orchestrator) | 500 | 353 | Anthropic official: SKILL.md body under 500 lines |
+| Meta-agent (`agents/magi-core.md`) | 160 | 75 | Synthesis agent: embeds extraction, voting, bias detection, output format |
+| Persona agents (`agents/{melchior,balthasar,caspar}.md`) | 130 | 102 | Self-contained persona + output format; 130 allows axis expansion |
+| Reference files (`references/*.md`) | 100 | 38-87 | Focused single-concern documents |
 | Example files (`examples/*.md`) | 100 | 78 | Illustrative, not normative |
 | comparison-format.md | 100 | 75 | Comparison prompt template + Phase 4 format |
 | voting-engine.md | 100 | 40 | Parameterized N-agent voting logic |

--- a/plugins/magi/skills/magi/references/judgment-rules.md
+++ b/plugins/magi/skills/magi/references/judgment-rules.md
@@ -20,6 +20,13 @@ Consolidate "Risks and Concerns" from all three MAGI, deduplicate, and reflect i
 - Per-option verdicts (Approve/Reject) are secondary information — displayed for completeness but the primary signal is the Recommendation tally
 - If 2+ options receive identical recommendation counts, compare average scores across recommending agents to break the tie
 
+## Reversibility
+
+MAGI Core computes a reversibility assessment from agent risk data:
+- **Low**: Hard to undo (e.g., database migration, public API contract). If confidence is Medium or lower, note in the judgment that caution is warranted.
+- **Medium**: Reversible with effort (e.g., internal service refactor)
+- **High**: Easily reversible (e.g., feature flag, configuration change)
+
 ## MAGI_JUDGMENT Schema — Synthesis Agent Output
 
 MAGI Core emits `<!-- MAGI_JUDGMENT {...} -->` at the end of its response. The orchestrator parses this for Phase 5 decisions.
@@ -29,6 +36,7 @@ MAGI Core emits `<!-- MAGI_JUDGMENT {...} -->` at the end of its response. The o
   "overall_verdict": "Approve | Reject | Conditional Approval | Indeterminate",
   "vote_tally": "string — e.g. '3:0', '2:1'",
   "confidence": "High | Medium | Low",
+  "reversibility": "High | Medium | Low",
   "bias_flags": ["string — detected bias patterns. Empty array if none"],
   "conditions": "string or null — aggregated conditions if any",
   "agents": [
@@ -47,6 +55,7 @@ MAGI Core emits `<!-- MAGI_JUDGMENT {...} -->` at the end of its response. The o
 - `overall_verdict`: Determined by voting engine. Must be one of the four values.
 - `vote_tally`: Format `X:Y` for majority or `X:Y:Z` for three-way split.
 - `confidence`: May be reduced by one level if `bias_flags` is non-empty.
+- `reversibility`: One of `High`, `Medium`, `Low`. Computed from agent risk assessments. If `Low` and `confidence` is `Medium` or `Low`, note caution in judgment.
 - `bias_flags`: Array of strings describing detected sycophancy or overcorrection patterns. Use `[]` if none.
 - `conditions`: Non-empty string if any agent issued Conditional Approval, otherwise `null`.
 - `agents`: Array with one entry per voting agent (advisory agents excluded).

--- a/plugins/magi/skills/magi/references/schema.md
+++ b/plugins/magi/skills/magi/references/schema.md
@@ -13,7 +13,7 @@ This is the authoritative schema for the structured output block emitted by each
       "rationale": "string — one-line justification"
     }
   },
-  "risks": ["string — each a distinct risk or concern. Empty array if none"]
+  "risks": ["string — each a distinct risk or concern. Empty array if none. Also accepts {severity, description} objects (see below)"]
 }
 ```
 
@@ -25,7 +25,10 @@ This is the authoritative schema for the structured output block emitted by each
 - `scores`: Object with agent-specific axis keys. Each agent has exactly 4 axes. Keys must match the agent's defined evaluation axes.
 - `scores.*.score`: Integer from 1 to 5 inclusive.
 - `scores.*.rationale`: Non-empty string.
-- `risks`: Array of strings. Use `[]` (empty array) if no risks identified.
+- `risks`: Array of strings OR objects. Persona agents emit strings; MAGI Core classifies severity during synthesis. Object form: `{"severity": "critical|moderate|informational", "description": "string"}`. Use `[]` if no risks.
+  - `critical`: Blocks deployment or causes outage
+  - `moderate`: Degrades quality or increases cost
+  - `informational`: Awareness item, no immediate action needed
 - The entire JSON block MUST be valid JSON enclosed in `<!-- MAGI_OUTPUT ... -->` HTML comment markers.
 
 ## Schema v1.1 — Comparison Mode

--- a/scripts/validate-judgment.sh
+++ b/scripts/validate-judgment.sh
@@ -69,6 +69,16 @@ case "$CONFIDENCE" in
 esac
 pass "confidence: $CONFIDENCE"
 
+# Step 5.5: Check reversibility (optional — backward compatible)
+REVERSIBILITY=$(echo "$MAGI_BLOCK" | jq -r '.reversibility // empty')
+if [ -n "$REVERSIBILITY" ]; then
+  case "$REVERSIBILITY" in
+    High|Medium|Low) ;;
+    *) fail "Invalid reversibility: $REVERSIBILITY (expected High/Medium/Low)" ;;
+  esac
+  pass "reversibility: $REVERSIBILITY"
+fi
+
 # Step 6: Check bias_flags (must be array)
 BIAS_TYPE=$(echo "$MAGI_BLOCK" | jq -r '.bias_flags | type')
 if [ "$BIAS_TYPE" != "array" ]; then

--- a/scripts/validate-output.sh
+++ b/scripts/validate-output.sh
@@ -132,12 +132,28 @@ else
   done
   pass "All scores valid (1-5 range with rationales)"
 
-  # Check risks array
+  # Check risks array (accepts strings or {severity, description} objects)
   RISKS_TYPE=$(echo "$MAGI_BLOCK" | jq -r '.risks | type')
   if [ "$RISKS_TYPE" != "array" ]; then
     fail "risks must be an array (got: $RISKS_TYPE)"
   fi
-  pass "risks is array"
+  # Validate each risk entry is string or valid severity object
+  RISK_COUNT=$(echo "$MAGI_BLOCK" | jq '.risks | length')
+  for i in $([ "$RISK_COUNT" -gt 0 ] && seq 0 $((RISK_COUNT - 1))); do
+    RISK_TYPE=$(echo "$MAGI_BLOCK" | jq -r ".risks[$i] | type")
+    if [ "$RISK_TYPE" = "object" ]; then
+      SEV=$(echo "$MAGI_BLOCK" | jq -r ".risks[$i].severity // empty")
+      case "$SEV" in
+        critical|moderate|informational) ;;
+        *) fail "risks[$i] invalid severity: $SEV (expected critical/moderate/informational)" ;;
+      esac
+      DESC=$(echo "$MAGI_BLOCK" | jq -r ".risks[$i].description // empty")
+      [ -n "$DESC" ] || fail "risks[$i] missing description"
+    elif [ "$RISK_TYPE" != "string" ]; then
+      fail "risks[$i] must be string or object (got: $RISK_TYPE)"
+    fi
+  done
+  pass "risks is valid array ($RISK_COUNT entries)"
 fi
 
 echo ""

--- a/tests/fixtures/e2e-agent-responses.txt
+++ b/tests/fixtures/e2e-agent-responses.txt
@@ -1,0 +1,62 @@
+#### [MELCHIOR-1]
+### Scores
+- Correctness & Rigor: 4 — Event-driven architecture is well-suited for this use case
+- Performance & Efficiency: 4 — Async processing eliminates blocking bottlenecks
+- Security: 3 — Message queue access controls need explicit configuration
+- Technical Consistency: 4 — Aligns with existing microservices patterns
+
+### Overall Analysis
+The proposal to adopt event-driven architecture for the notification service is technically sound. Async message processing eliminates the blocking bottleneck in the current synchronous pipeline. Security requires explicit queue ACL configuration to prevent unauthorized message injection. The pattern aligns with the existing microservices architecture.
+
+### Verdict
+Approve
+
+### Risks and Concerns
+- Message queue ACL misconfiguration could allow unauthorized access
+- Dead letter queue handling must be defined before production deployment
+
+### Structured Output
+
+<!-- MAGI_OUTPUT {"schema_version":"1.0","verdict":"Approve","conditions":null,"scores":{"correctness_rigor":{"score":4,"rationale":"Event-driven architecture is well-suited for this use case"},"performance_efficiency":{"score":4,"rationale":"Async processing eliminates blocking bottlenecks"},"security":{"score":3,"rationale":"Message queue access controls need explicit configuration"},"technical_consistency":{"score":4,"rationale":"Aligns with existing microservices patterns"}},"risks":["Message queue ACL misconfiguration could allow unauthorized access","Dead letter queue handling must be defined before production deployment"]} -->
+
+#### [BALTHASAR-2]
+### Scores
+- Maintainability & Readability: 3 — Event-driven code is harder to trace than synchronous flows
+- Testability: 2 — Integration testing of async event chains requires significant infrastructure
+- Operability & Observability: 3 — Distributed tracing needed but not yet in place
+- Team Impact: 3 — Team has limited experience with event-driven patterns
+
+### Overall Analysis
+The 6-month horizon reveals the critical risk: debugging event-driven flows requires distributed tracing that the team does not currently have. Integration testing of async event chains demands significant test infrastructure investment. The team's limited experience with event-driven patterns increases the onboarding burden. At the 2-year horizon, if the team does not invest in observability tooling, incident response times will degrade.
+
+### Verdict
+Reject
+
+### Risks and Concerns
+- Team lacks event-driven debugging experience, increasing incident resolution time
+- Integration test infrastructure gap will lead to undertested event chains
+- Missing distributed tracing makes production debugging extremely difficult
+
+### Structured Output
+
+<!-- MAGI_OUTPUT {"schema_version":"1.0","verdict":"Reject","conditions":null,"scores":{"maintainability_readability":{"score":3,"rationale":"Event-driven code is harder to trace than synchronous flows"},"testability":{"score":2,"rationale":"Integration testing of async event chains requires significant infrastructure"},"operability_observability":{"score":3,"rationale":"Distributed tracing needed but not yet in place"},"team_impact":{"score":3,"rationale":"Team has limited experience with event-driven patterns"}},"risks":["Team lacks event-driven debugging experience","Integration test infrastructure gap","Missing distributed tracing makes production debugging difficult"]} -->
+
+#### [CASPAR-3]
+### Scores
+- Design Elegance: 4 — Clean decoupling of notification concerns from business logic
+- Innovation & Competitiveness: 4 — Industry standard pattern for notification services
+- Feasibility: 4 — Incremental adoption possible via hybrid sync/async approach
+- Adaptability & Extensibility: 5 — Event-driven architecture naturally supports new notification channels
+
+### Overall Analysis
+The event-driven approach elegantly decouples notification delivery from business logic, creating a clean boundary that the current synchronous design lacks. The architecture naturally supports adding new notification channels without modifying the core service. Incremental adoption via a hybrid sync/async transition reduces migration risk. The opportunity cost of staying synchronous is growing as notification volume increases.
+
+### Verdict
+Approve
+
+### Risks and Concerns
+- Hybrid transition period increases system complexity temporarily
+
+### Structured Output
+
+<!-- MAGI_OUTPUT {"schema_version":"1.0","verdict":"Approve","conditions":null,"scores":{"design_elegance":{"score":4,"rationale":"Clean decoupling of notification concerns from business logic"},"innovation_competitiveness":{"score":4,"rationale":"Industry standard pattern for notification services"},"feasibility":{"score":4,"rationale":"Incremental adoption possible via hybrid sync/async approach"},"adaptability_extensibility":{"score":5,"rationale":"Event-driven architecture naturally supports new notification channels"}},"risks":["Hybrid transition period increases system complexity temporarily"]} -->

--- a/tests/test-e2e.sh
+++ b/tests/test-e2e.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# MAGI E2E Integration Test
+# Tests extraction, vote tally, and dissenter identification from mock agent responses
+# No agent execution — tests extraction and voting logic only
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OUTPUT_VALIDATOR="$SCRIPT_DIR/../scripts/validate-output.sh"
+FIXTURE="$SCRIPT_DIR/fixtures/e2e-agent-responses.txt"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  TOTAL=$((TOTAL + 1))
+  if [ "$expected" = "$actual" ]; then
+    echo -e "  ${GREEN}PASS${NC}  $label (expected: $expected)"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}  $label (expected: $expected, got: $actual)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "━━━ MAGI E2E Integration Test ━━━"
+echo ""
+
+# Step 1: Extract the 3 MAGI_OUTPUT blocks
+echo "--- Step 1: Extract MAGI_OUTPUT blocks ---"
+
+BLOCKS=$(sed -n 's/.*<!-- MAGI_OUTPUT \(.*\) -->.*/\1/p' "$FIXTURE")
+BLOCK_COUNT=$(echo "$BLOCKS" | wc -l | tr -d ' ')
+
+assert_eq "Extracted 3 MAGI_OUTPUT blocks" "3" "$BLOCK_COUNT"
+
+# Step 2: Validate each block with validate-output.sh
+echo ""
+echo "--- Step 2: Validate each MAGI_OUTPUT block ---"
+
+AGENT_NAMES=("MELCHIOR-1" "BALTHASAR-2" "CASPAR-3")
+IDX=0
+
+# Split fixture by agent headers and validate each
+for agent_name in "${AGENT_NAMES[@]}"; do
+  # Extract this agent's section from header to EOF, then trim at next header
+  AGENT_SECTION=$(awk "/^#### \[$agent_name\]/{found=1; next} /^#### \[/{if(found) exit} found{print}" "$FIXTURE")
+
+  TOTAL=$((TOTAL + 1))
+  if echo "$AGENT_SECTION" | bash "$OUTPUT_VALIDATOR" >/dev/null 2>&1; then
+    echo -e "  ${GREEN}PASS${NC}  $agent_name MAGI_OUTPUT validates"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}  $agent_name MAGI_OUTPUT validation failed"
+    FAIL=$((FAIL + 1))
+  fi
+  IDX=$((IDX + 1))
+done
+
+# Step 3: Verify vote tally (2 Approve, 1 Reject = 2:1)
+echo ""
+echo "--- Step 3: Verify vote tally ---"
+
+APPROVE_COUNT=$(echo "$BLOCKS" | jq -r '.verdict' | grep -c "Approve" || true)
+REJECT_COUNT=$(echo "$BLOCKS" | jq -r '.verdict' | grep -c "Reject" || true)
+
+assert_eq "Approve count" "2" "$APPROVE_COUNT"
+assert_eq "Reject count" "1" "$REJECT_COUNT"
+
+TALLY="${APPROVE_COUNT}:${REJECT_COUNT}"
+assert_eq "Vote tally" "2:1" "$TALLY"
+
+# Step 4: Identify the dissenter
+echo ""
+echo "--- Step 4: Identify dissenter ---"
+
+# The dissenter is the agent whose verdict differs from the majority
+# Parse each block's verdict and find the Reject
+DISSENTER_IDX=0
+LINE_NUM=0
+DISSENTER_NAME=""
+while IFS= read -r line; do
+  VERDICT=$(echo "$line" | jq -r '.verdict')
+  if [ "$VERDICT" = "Reject" ]; then
+    DISSENTER_NAME="${AGENT_NAMES[$LINE_NUM]}"
+    break
+  fi
+  LINE_NUM=$((LINE_NUM + 1))
+done <<< "$BLOCKS"
+
+assert_eq "Dissenter identified" "BALTHASAR-2" "$DISSENTER_NAME"
+
+echo ""
+echo "━━━ Results: $PASS/$TOTAL passed, $FAIL failed ━━━"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+else
+  exit 0
+fi


### PR DESCRIPTION
## Summary

Implements all 12 retained issues from the MAGI v6 Evolution Roadmap (#46), after MAGI's own 3:0 ruling pruned the original 27 proposals down to 12.

## Changes

### P0 — Critical Evolution
- **#47** Structural Disagreement Incentives: BALTHASAR must articulate 2-year worst-case before approving; CASPAR must name the best alternative not chosen

### P1 — High Value
- **#51** MAGI Core Sonnet Downgrade: Synthesis agent runs on `model: sonnet` (extraction/voting/formatting doesn't need Opus reasoning)
- **#54** Cross-Axis Tension Visualization: MAGI Core identifies top 2-3 trade-offs between agents' axes (e.g., Security:5 + Feasibility:2)
- **#56** E2E Integration Test: Mock 3-agent responses with 2:1 split, verify extraction, vote tally, and dissenter identification (8 assertions)
- **#57** Pre-Commit Hook: `.githooks/pre-commit` auto-runs `check-sizes.sh` + `test-extraction.sh` on plugin commits

### P2 — Valuable
- **#53** Always-On Micro-Dialectic: On 2:1 split, auto re-spawns dissenter for 2-3 line rebuttal (single agent call, not full dialectic)
- **#55** Verdict-Linked Action Plans: Recommended actions must reference specific files/functions when agents investigated codebase
- **#64** Agent Failure Retry: One retry with explicit "emit MAGI_OUTPUT" instruction before falling back to prose extraction
- **#66** Tiered Risk Severity: Risks classified as critical/moderate/informational; critical risk + Approve verdict = sycophancy signal
- **#69** Reversibility Metric: `reversibility` field (Low/Medium/High) in MAGI_JUDGMENT; Low + Medium confidence = caution warning

### New Skills
- **#60** `/magi-review`: Reads git diff, summarizes changes, invokes /magi for code review deliberation
- **#59** `/magi-premortem`: Agents assume proposal failed, write failure narratives (no voting — pure failure analysis)

## Verification
- `check-sizes.sh`: All files within limits, governance values match
- `test-extraction.sh`: 15/15 passed
- `test-e2e.sh`: 8/8 passed

Closes #47
Closes #51
Closes #53
Closes #54
Closes #55
Closes #56
Closes #57
Closes #59
Closes #60
Closes #64
Closes #66
Closes #69

## Test plan
- [ ] `bash scripts/check-sizes.sh` — all within limits
- [ ] `bash tests/test-extraction.sh` — 15/15 pass
- [ ] `bash tests/test-e2e.sh` — 8/8 pass
- [ ] `/magi` with a test topic — verify tension visualization and micro-dialectic on 2:1 split
- [ ] `/magi-review` — verify git diff reading and topic generation
- [ ] `/magi-premortem` — verify failure narrative mode
- [ ] `git config core.hooksPath .githooks` then commit a plugin change — verify pre-commit hook fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced new code review and pre-mortem failure analysis capabilities
  * Enhanced judgment output with reversibility assessment and comprehensive risk classification
  * Strengthened agent decision-making with explicit approval requirements

* **Documentation**
  * Updated governance and project structure documentation

* **Tests**
  * Added end-to-end integration testing for core workflows

* **Chores**
  * Implemented automated pre-commit validation checks
  * Extended validation schemas for enhanced output verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->